### PR TITLE
Remove maxLength for note title

### DIFF
--- a/src/models/noteSchema.js
+++ b/src/models/noteSchema.js
@@ -6,7 +6,6 @@ const noteSchema = new Schema({
     type: String,
     required: [true, "Title is required"],
     minLength: [5, "Title must be at least 5 characters"],
-    maxLength: [50, "Title must be less than 50 characters"],
   },
   note: {
     type: String,


### PR DESCRIPTION
Remove the length limit for the note title, as a new feature has been added for adding a question to notes. On the front end, this limit was changed to 400 characters.